### PR TITLE
Require PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "docs": "https://github.com/noahjahn/craft-php-fpm-status-monitor/blob/main/README.md"
     },
     "require": {
+        "php": "^8.0",
         "craftcms/cms": "^3.7.35"
     },
     "autoload": {


### PR DESCRIPTION
If the plugin is only being tested on PHP 8, then it should explicitly require it.